### PR TITLE
refactor: Update Docker CI for Scala, SBT, and Java 21

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Needed to push packages to ghcr.io
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      # If your project uses submodules (like the reference web-sugar-startup did),
+      # you might need to add:
+      # with:
+      #   submodules: 'recursive'
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin' # Using Eclipse Temurin, consistent with Dockerfile
+
+    - name: Cache SBT dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.sbt
+          ~/.ivy2/cache
+          ~/.coursier/cache
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt', '**/*.scala', 'project/build.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-sbt-
+
+    - name: Run SBT stage
+      run: sbt clean stage # This command compiles the app and stages it in target/universal/stage
+
+    - name: Log in to the GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GH_PAT }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: . # The Dockerfile is in the root
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: Define the base runtime environment
+FROM eclipse-temurin:21-jdk-alpine
+
+WORKDIR /app
+
+# Set timezone if needed (optional, but good practice for consistency)
+RUN apk add --no-cache tzdata &&     cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime &&     echo "Asia/Shanghai" > /etc/timezone
+
+# Add bash if your startup script or operations require it (as in reference Dockerfile)
+RUN apk add --no-cache bash
+
+# This directory will contain the staged application (bin, lib, etc.)
+# The contents will be copied from the SBT stage task output
+COPY target/universal/stage /app/
+
+# Define the default command to run the application.
+# This assumes your sbt-native-packager setup produces a launch script at /app/bin/<project-name>
+# Replace <project-name> with the actual name if known, or it might be 'app' based on reference.
+# Also, ensure the config paths are correct if they are baked into the launch script
+# or need to be passed as arguments.
+# The reference CMD was: ["/bin/bash", "/server/bin/app", "-Dconfig.file=/server/config/application.conf", "-Dlogback.configurationFile=/server/config/logback.xml"]
+# We will adapt this. Assuming the app name from sbt build is 'app'.
+CMD ["/bin/bash", "/app/bin/app", "-Dconfig.file=/app/conf/application.conf", "-Dlogback.configurationFile=/app/conf/logback.xml"]
+
+# Expose the port the application listens on (e.g., 8080).
+# This should match the application's configuration.
+EXPOSE 8080


### PR DESCRIPTION
This commit refactors the Docker image building process to support a Scala project built with SBT and requiring Java 21.
